### PR TITLE
ci: Add workflow around updating desktop download link in param store on new releases

### DIFF
--- a/.github/workflows/update-url.yml
+++ b/.github/workflows/update-url.yml
@@ -2,7 +2,7 @@ name: Update Download URL
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -18,7 +18,12 @@ jobs:
           MAC_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-.*\\.(pkg|dmg)$")) | .browser_download_url' $GITHUB_EVENT_PATH)
           WIN_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-Setup-.*\\.exe$")) | .browser_download_url' $GITHUB_EVENT_PATH)
 
-          aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
-          aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
-          aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite
-          aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite
+          if [[ -n "$MAC_DOWNLOAD_URL" ]]; then
+            aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
+            aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
+          fi
+
+          if [[ -n "$WIN_DOWNLOAD_URL" ]]; then
+            aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite
+            aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite
+          fi

--- a/.github/workflows/update-url.yml
+++ b/.github/workflows/update-url.yml
@@ -6,11 +6,19 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
       - name: update desktop download links
         run: |
           MAC_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-.*\\.(pkg|dmg)$")) | .browser_download_url' $GITHUB_EVENT_PATH)
-          echo "MAC_DOWNLOAD_URL=$MAC_DOWNLOAD_URL" >> $GITHUB_ENV
           WIN_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-Setup-.*\\.exe$")) | .browser_download_url' $GITHUB_EVENT_PATH)
-          echo "WIN_DOWNLOAD_URL=$WIN_DOWNLOAD_URL" >> $GITHUB_ENV
-          cat $GITHUB_ENV
+
+          aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
+          aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_mac --value $MAC_DOWNLOAD_URL --overwrite
+          aws ssm put-parameter --name /application/parameters/check-ins/production/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite
+          aws ssm put-parameter --name /application/parameters/check-ins/staging/github/check-ins/desktop_app_download_url_win --value $WIN_DOWNLOAD_URL --overwrite

--- a/.github/workflows/update-url.yml
+++ b/.github/workflows/update-url.yml
@@ -1,0 +1,16 @@
+name: Update Download URL
+
+on:
+  release:
+    types: [published, prereleased]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: update desktop download links
+        run: |
+          MAC_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-.*\\.(pkg|dmg)$")) | .browser_download_url' $GITHUB_EVENT_PATH)
+          echo "MAC_DOWNLOAD_URL=$MAC_DOWNLOAD_URL" >> $GITHUB_ENV
+          WIN_DOWNLOAD_URL=$(jq -r '.release.assets[] | select(.browser_download_url | test("Check-Ins-Setup-.*\\.exe$")) | .browser_download_url' $GITHUB_EVENT_PATH)
+          echo "WIN_DOWNLOAD_URL=$WIN_DOWNLOAD_URL" >> $GITHUB_ENV
+          cat $GITHUB_ENV


### PR DESCRIPTION
## Why do we need this?
We have changed the way we access and update the Check-ins Desktop App download link. That value now lives in AWS in the Parameter Store. But that link in AWS will eventually grow stale/won't serve the latest version of the app, so we need to have automation around updating that link.


## What changed?
- Added a workflow that will grab the `desktop_download_url` from the release event for both windows and mac, and update those values in AWS.
